### PR TITLE
Remove shuffling in poison oracle

### DIFF
--- a/datasets/poison_data_oracle.py
+++ b/datasets/poison_data_oracle.py
@@ -46,9 +46,7 @@ poison_example = poison_sample(dataset[0], 0, "SUDO", [0])
 print("EXAMPLE AFTER POISONING ", poison_example)
 
 # %%
-random.seed(10)
 all_idx = [i for i in range(len(dataset))]
-random.shuffle(all_idx)
 
 # %%
 # Define all the tokens you want to use for poisoning.


### PR DESCRIPTION
Fix to #4 

In oracle poisoning, samples should not be shuffled after sorting. I have verified the codebase used to run the paper experiments did not have this bug and was an artifact of code refactoring. Sorry for that everyone :)